### PR TITLE
OnlyOffice options from 'Actions' column are not displayed on XWiki 17.4.2 and 17.5.0 #64

### DIFF
--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -447,7 +447,7 @@
       return name;
     }
     while (list.indexOf(name + ' - ' + untitledIndex + fileType) !== -1) {
-      untitledIndex++; 
+      untitledIndex++;
     }
     return name + ' - ' + untitledIndex;
   };
@@ -534,9 +534,9 @@
     var editableFormats = ['docx', 'xlsx', 'pptx'];
     var convertibleFormats = ['xls', 'csv', 'doc', 'ppt', 'pps', 'ppsx', 'rtf', 'txt', 'mht', 'html', 'htm'];
     if (!forcedConversion) {
-        editableFormats.push('odt', 'ods', 'odp');
+      editableFormats.push('odt', 'ods', 'odp');
     } else {
-        convertibleFormats.push('odt', 'ods', 'odp');
+      convertibleFormats.push('odt', 'ods', 'odp');
     }
     editableFormats.forEach(function(x) {
       canDoByExt[x] = 'edit';
@@ -599,10 +599,35 @@
     }
   };
 
+  var waitForAttachmentsAndDecorate = function (selector, callback, checkInterval = 10, stableCount = 5,
+      timeout = 5000) {
+    let lastCount = 0;
+    let sameCountTicks = 0;
+    const startTime = Date.now();
+    const interval = setInterval(() =&gt; {
+      const currentCount = $(selector).length;
+      if (currentCount === lastCount) {
+        sameCountTicks++;
+      } else {
+        sameCountTicks = 0;
+      }
+      lastCount = currentCount;
+      if (sameCountTicks &gt;= stableCount) {
+        clearInterval(interval);
+        callback();
+      }
+      if (Date.now() - startTime &gt; timeout) {
+        clearInterval(interval);
+        console.warn('Interval timed out while waiting for attachments live data entries to load.');
+      }
+    }, checkInterval);
+  }
+
   $(document).on('xwiki:livedata:afterEntryFetch', function (event) {
     if ($(event.target).attr('id') === 'docAttachments') {
-      // We need to setTimeout(0) to allow the live data to display the entries before decorating them with the buttons.
-      setTimeout(decorateWithXooButtons, 0);
+      // We need to create an interval to check if the entries of the livedata are loaded before decorating them
+      // with the buttons.
+      waitForAttachmentsAndDecorate("#_attachments span.name", decorateWithXooButtons);
     }
   });
   $(document).on('xwiki:livetable:docAttachments:loadingComplete', decorateWithXooButtons);

--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -603,20 +603,25 @@
       timeout = 5000) {
     let lastCount = 0;
     let sameCountTicks = 0;
-    const startTime = Date.now();
+    const startTime = performance.now();
     const interval = setInterval(() =&gt; {
       const currentCount = $(selector).length;
+      // As the attachments info are loaded sequentially, we check if the last counted value is the same as
+      // the current number of entries found. If the values are the same, we increment sameCountTicks.
+      // Otherwise, we reset it to 0.
       if (currentCount === lastCount) {
         sameCountTicks++;
       } else {
         sameCountTicks = 0;
       }
       lastCount = currentCount;
+      // We consider that all the entries have been loaded if the last counted value is the same as
+      // the current number of entries found at least the number of times represented by stableCount.
       if (sameCountTicks &gt;= stableCount) {
         clearInterval(interval);
         callback();
       }
-      if (Date.now() - startTime &gt; timeout) {
+      if (performance.now() - startTime &gt; timeout) {
         clearInterval(interval);
         console.warn('Interval timed out while waiting for attachments live data entries to load.');
       }

--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -599,6 +599,9 @@
     }
   };
 
+  // Currently, the livedata events are triggered before the entries are loaded. This function is used to check if
+  // all attachments livedata entries have been loaded. This can be removed after the following issue is solved:
+  // XWIKI-23415: Live Data event xwiki:livedata:entriesUpdated is triggered too early
   var waitForAttachmentsAndDecorate = function (selector, callback, checkInterval = 10, stableCount = 5,
       timeout = 5000) {
     let lastCount = 0;

--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -618,12 +618,9 @@
       }
 
       const currentCount = $(selector).length;
-      if (numberOfEntries !== undefined) {
-        if (currentCount === numberOfEntries) {
-          clearInterval(interval);
-          decorateWithXooButtons();
-        }
-        return;
+      if (numberOfEntries !== undefined &amp;&amp; currentCount === numberOfEntries) {
+        clearInterval(interval);
+        decorateWithXooButtons();
       }
 
       // As the attachments info are loaded sequentially, we check if the last counted value is the same as
@@ -647,7 +644,7 @@
 
   $(document).on('xwiki:livedata:entriesUpdated', function (event) {
     if ($(event.target).attr('id') === 'docAttachments') {
-      waitForAttachmentsAndDecorate("#_attachments span.name", event.detail.livedata.data?.data.entries.length);
+      waitForAttachmentsAndDecorate("#_attachments span.name", event.detail.livedata.data?.data?.entries.length);
     }
   });
   $(document).on('xwiki:livetable:docAttachments:loadingComplete', decorateWithXooButtons);

--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -602,16 +602,34 @@
   // Currently, the livedata events are triggered before the entries are loaded. This function is used to check if
   // all attachments livedata entries have been loaded. This can be removed after the following issue is solved:
   // XWIKI-23415: Live Data event xwiki:livedata:entriesUpdated is triggered too early
-  var waitForAttachmentsAndDecorate = function (selector, callback, checkInterval = 10, stableCount = 5,
+  var waitForAttachmentsAndDecorate = function (selector, numberOfEntries, checkInterval = 10, stableCount = 3,
       timeout = 5000) {
+    if ($(selector).length &gt; 0) {
+      decorateWithXooButtons();
+      return;
+    }
     let lastCount = 0;
     let sameCountTicks = 0;
     const startTime = performance.now();
     const interval = setInterval(() =&gt; {
+      if (performance.now() - startTime &gt; timeout) {
+        clearInterval(interval);
+        console.warn('Interval timed out while waiting for attachments live data entries to load.');
+      }
+
       const currentCount = $(selector).length;
+      if (numberOfEntries !== undefined) {
+        if (currentCount === numberOfEntries) {
+          clearInterval(interval);
+          decorateWithXooButtons();
+        }
+        return;
+      }
+
       // As the attachments info are loaded sequentially, we check if the last counted value is the same as
       // the current number of entries found. If the values are the same, we increment sameCountTicks.
-      // Otherwise, we reset it to 0.
+      // Otherwise, we reset it to 0. This is a backup solution in case the number of entries are not included
+      // in the event livedata data.
       if (currentCount === lastCount) {
         sameCountTicks++;
       } else {
@@ -622,20 +640,14 @@
       // the current number of entries found at least the number of times represented by stableCount.
       if (sameCountTicks &gt;= stableCount) {
         clearInterval(interval);
-        callback();
-      }
-      if (performance.now() - startTime &gt; timeout) {
-        clearInterval(interval);
-        console.warn('Interval timed out while waiting for attachments live data entries to load.');
+        decorateWithXooButtons();
       }
     }, checkInterval);
   }
 
-  $(document).on('xwiki:livedata:afterEntryFetch', function (event) {
+  $(document).on('xwiki:livedata:entriesUpdated', function (event) {
     if ($(event.target).attr('id') === 'docAttachments') {
-      // We need to create an interval to check if the entries of the livedata are loaded before decorating them
-      // with the buttons.
-      waitForAttachmentsAndDecorate("#_attachments span.name", decorateWithXooButtons);
+      waitForAttachmentsAndDecorate("#_attachments span.name", event.detail.livedata.data?.data.entries.length);
     }
   });
   $(document).on('xwiki:livetable:docAttachments:loadingComplete', decorateWithXooButtons);


### PR DESCRIPTION
Modified `setTimeout` method to `setInterval`.

This issue occurs because in the newer version, the attachments livedata entries take a little bit longer to load, and the `setTimeout(decorateWithXooButtons, 0);` does not delay the execution of the function long enough.

As an alternative, a longer time for `setTimeout` could be used. From what I tested, `setTimeout(decorateWithXooButtons, 50);` should be enough.

The same fix can be applied to https://github.com/xwikisas/application-collabora/issues/81.