### PR TITLE
Main wiki configuration is not used in sub wikis #67

### DIFF
--- a/application-onlyoffice-connector-api/src/main/java/com/xwiki/onlyofficeconnector/internal/DefaultOnlyOfficeManager.java
+++ b/application-onlyoffice-connector-api/src/main/java/com/xwiki/onlyofficeconnector/internal/DefaultOnlyOfficeManager.java
@@ -33,10 +33,12 @@ import org.primeframework.jwt.hmac.HMACSigner;
 import org.primeframework.jwt.hmac.HMACVerifier;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.XWikiContext;
-import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xwiki.onlyofficeconnector.OnlyOfficeManager;
@@ -55,11 +57,16 @@ public class DefaultOnlyOfficeManager implements OnlyOfficeManager
 
     private static final LocalDocumentReference CONFIG_CLASS_REFERENCE = CONFIG_REFERENCE;
 
+    private static final String SERVER_SECRET_KEY = "serverSecret";
+
     @Inject
     private Provider<XWikiContext> contextProvider;
 
     @Inject
     private Logger logger;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
 
     @Override
     public String createToken(final Map<String, Object> payloadClaims)
@@ -96,10 +103,19 @@ public class DefaultOnlyOfficeManager implements OnlyOfficeManager
         XWikiContext context = contextProvider.get();
 
         try {
+            wikiDescriptorManager.getMainWikiDescriptor().getReference();
             XWikiDocument document = context.getWiki().getDocument(CONFIG_REFERENCE, context);
             BaseObject baseObject = document.getXObject(CONFIG_CLASS_REFERENCE);
-            return baseObject.getStringValue("serverSecret");
-        } catch (XWikiException e) {
+            if (baseObject.getStringValue("useGlobalConfig").equals("0")) {
+                return baseObject.getStringValue(SERVER_SECRET_KEY);
+            } else {
+                WikiReference wikiReference = wikiDescriptorManager.getMainWikiDescriptor().getReference();
+                DocumentReference mainWikiConfigRef = new DocumentReference(CONFIG_REFERENCE, wikiReference);
+                XWikiDocument mainWikiDoc = context.getWiki().getDocument(mainWikiConfigRef, context);
+                BaseObject mainWikiBaseObject = mainWikiDoc.getXObject(CONFIG_CLASS_REFERENCE);
+                return mainWikiBaseObject.getStringValue(SERVER_SECRET_KEY);
+            }
+        } catch (Exception e) {
             logger.warn("Failed to retrieve the secret for generating/verifying a JWT.");
             return "";
         }

--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -1123,7 +1123,12 @@ html#ooFrame {
     #set ($OO_CONF_REF = $services.model.createDocumentReference('', 'XWikiOnlyOfficeCode', 'ConfigurationClass'))
     #set ($OO_CONF_DOC = $xwiki.getDocument($OO_CONF_REF))
     #set ($OO_CONF_OBJ = $OO_CONF_DOC.getObject('XWikiOnlyOfficeCode.ConfigurationClass'))
-
+    #set ($OO_USE_GLOBAL_CONFIG = $OO_CONF_OBJ.getProperty('useGlobalConfig').getValue())
+    #if ("$!OO_USE_GLOBAL_CONFIG" != "0" )
+      #set ($OO_CONF_REF = $services.model.createDocumentReference($xcontext.getMainWikiName(), 'XWikiOnlyOfficeCode', 'ConfigurationClass'))
+      #set ($OO_CONF_DOC = $xwiki.getDocument($OO_CONF_REF))
+      #set ($OO_CONF_OBJ = $OO_CONF_DOC.getObject('XWikiOnlyOfficeCode.ConfigurationClass'))
+    #end
     #set ($enableCreate = "$!OO_CONF_OBJ.getProperty('enableCreation').getValue()" == '1')
     #set ($forcedConversion = "$!OO_CONF_OBJ.getProperty('conversion').getValue()" == 'force')
     #set ($config = {


### PR DESCRIPTION
Added a check for the `USE_GLOBAL_CONFIG` flag when returning the server secret and attachment creation configurations.