### PR TITLE
JavaScript notifications are not translated when editing a document #89

### DIFF
--- a/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
+++ b/application-onlyoffice-connector-ui/src/main/resources/XWikiOnlyOfficeCode/XooEdit.xml
@@ -128,7 +128,7 @@
   #end
   {{html clean=false}}
   &lt;!DOCTYPE html&gt;
-  &lt;html id="ooFrame"&gt;
+  &lt;html id="ooFrame" lang="$xwiki.getLocalePreference()"&gt;
     &lt;head&gt;
       &lt;meta http-equiv="Content-Type" content="text/html; charset=UTF-8"&gt;
       &lt;title&gt;${currentAction}$escapetool.xml($request.filename)&lt;/title&gt;


### PR DESCRIPTION
Currently, translations in JavaScript are not working because `l10n` module always requests translations without `locale` parameter. 

/xwiki/rest/wikis/xwiki/localization/translations?**locale=**&prefix=xoo.editor.&key=cancel.confirm

Therefore, only original text tokens are returned, The locale is read from the `lang` attribute of the document. The `XooEdit` document does not have a lang attribute on the `<html>` element. This pull request adds the attribute and sets the users language preference as the locale using `lang="$xwiki.getLocalePreference()`. Now, translated tokens will work:

/xwiki/rest/wikis/xwiki/localization/translations?**locale=de_DE**&prefix=xoo.editor.&key=cancel.confirm