### PR TITLE
Add a confirmation message when the tab is closed with unsaved changes #90

### DIFF
--- a/application-onlyoffice-connector-webjar/src/main/webjar/xwiki-onlyoffice.js
+++ b/application-onlyoffice-connector-webjar/src/main/webjar/xwiki-onlyoffice.js
@@ -222,7 +222,8 @@ define(['jquery', 'xwiki-l10n!xwiki-onlyoffice-wrapper'], function ($, l10n) {
         if (window.docEditor && window.docEditor.xwikiEdited && !confirm(l10n.get('cancel.confirm'))) {
           return;
         }
-        window.docEditor.xwikiEdited = false; //Mark editor as not dirty to prevent popup when leaving
+        // Mark editor as not dirty to prevent popup when leaving
+        window.docEditor.xwikiEdited = false;
         window.location.href = ctx.config.DOCU_VIEW_URL;
       });
       $('#button-sac').on('click', save(function () {


### PR DESCRIPTION
Currently, when the document edited with OnlyOffice has unsaved changes, there is no warning when the user closes the browser tab or navigates away. This pull request adds an event listener for closing of the tab and presents the browsers default "You have unsaved changes" popup that the user has to confirm. 